### PR TITLE
Improve repository content normalization and release rendering

### DIFF
--- a/PSMaintenance.Tests/DocumentationPlannerTests.cs
+++ b/PSMaintenance.Tests/DocumentationPlannerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -39,5 +40,213 @@ public class DocumentationPlannerTests
         Assert.Contains(res.Items, i => i.Title.Contains("Readme", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(res.Items, i => i.Title.Contains("Changelog", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(res.Items, i => i.Title.Contains("License", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_RemoteRepositoryPaths_Classifies_TemplateDocs_As_SourceDocs()
+    {
+        var root = CreateTempModule(out var internals);
+        var finder = new DocumentationFinder();
+        var planner = new DocumentationPlanner(finder);
+        var client = new FakeRepoClient();
+
+        client.Files["docs"] = new List<(string Name, string Path)>
+        {
+            ("2022-03-20.md", "docs/2022-03-20.md"),
+            ("Use-Git.md", "docs/Use-Git.md")
+        };
+
+        client.Content["docs/2022-03-20.md"] = """
+        ---
+        permalink: /2022/03/20/
+        ---
+
+        {% for post in site.posts %}
+        * [{{ post.title }}]({{ post.url }})
+        {% endfor %}
+        """;
+        client.Content["docs/Use-Git.md"] = """
+        ## Use-Git
+
+        [Out-Git](Out-Git.md)
+        """;
+
+        var req = new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            Online = true,
+            RepositoryPaths = new[] { "docs" }
+        };
+
+        var res = planner.Execute(req, client);
+
+        var templateDoc = Assert.Single(res.Items, i => string.Equals(i.FileName, "2022-03-20.md", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("DOCSOURCE", templateDoc.Kind);
+        Assert.Contains("~~~markdown", templateDoc.Content, StringComparison.Ordinal);
+        Assert.Contains("{% for post in site.posts %}", templateDoc.Content, StringComparison.Ordinal);
+
+        var normalDoc = Assert.Single(res.Items, i => string.Equals(i.FileName, "Use-Git.md", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("DOC", normalDoc.Kind);
+    }
+
+    [Fact]
+    public void Execute_LocalReadme_Rewrites_Document_Links_To_Blob_And_Assets_To_Raw()
+    {
+        var root = CreateTempModule(out var internals);
+        File.WriteAllText(Path.Combine(root, "README.md"), """
+        [Guide](docs/Use-Git.md)
+        ![Logo](assets/ugit.svg)
+        """);
+
+        var planner = new DocumentationPlanner(new DocumentationFinder());
+        var res = planner.Execute(new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            ProjectUri = "https://github.com/StartAutomating/ugit"
+        });
+
+        var readme = Assert.Single(res.Items, i => string.Equals(i.FileName, "README.md", StringComparison.OrdinalIgnoreCase) && string.Equals(i.Source, "Local", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("https://github.com/StartAutomating/ugit/blob/main/docs/Use-Git.md", readme.Content, StringComparison.Ordinal);
+        Assert.Contains("https://raw.githubusercontent.com/StartAutomating/ugit/main/assets/ugit.svg", readme.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Changelog_Builds_Typed_Releases()
+    {
+        var root = CreateTempModule(out var internals);
+        File.WriteAllText(Path.Combine(root, "CHANGELOG.md"), """
+        # Changelog
+
+        ## [1.2.3] - 2024-12-07
+        - Added support for structured releases.
+
+        ## [1.2.2] - 2024-10-16
+        - Previous release.
+        """);
+
+        var planner = new DocumentationPlanner(new DocumentationFinder());
+        var res = planner.Execute(new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            ProjectUri = "https://github.com/StartAutomating/ugit"
+        });
+
+        var releases = Assert.Single(res.Items, i => string.Equals(i.Kind, "RELEASES", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(releases.Releases);
+        Assert.Equal(2, releases.Releases!.Count);
+        Assert.Equal("1.2.3", releases.Releases[0].Tag);
+        Assert.Equal("2024-12-07", releases.Releases[0].PublishedAt?.ToString("yyyy-MM-dd"));
+        Assert.Equal("https://github.com/StartAutomating/ugit/releases/tag/1.2.3", releases.Releases[0].Url);
+        Assert.Contains("Total releases: 2", releases.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Changelog_Infers_Prerelease_From_Tag()
+    {
+        var root = CreateTempModule(out var internals);
+        File.WriteAllText(Path.Combine(root, "CHANGELOG.md"), """
+        # Changelog
+
+        ## [1.2.4-preview1] - 2025-01-03
+        - Preview release.
+        """);
+
+        var planner = new DocumentationPlanner(new DocumentationFinder());
+        var res = planner.Execute(new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            ProjectUri = "https://github.com/StartAutomating/ugit"
+        });
+
+        var releases = Assert.Single(res.Items, i => string.Equals(i.Kind, "RELEASES", StringComparison.OrdinalIgnoreCase));
+        var preview = Assert.Single(releases.Releases!);
+        Assert.True(preview.IsPrerelease);
+        Assert.Equal("https://github.com/StartAutomating/ugit/releases/tag/1.2.4-preview1", preview.Url);
+    }
+
+    [Fact]
+    public void Execute_Changelog_Merges_Repository_Release_Metadata()
+    {
+        var root = CreateTempModule(out var internals);
+        File.WriteAllText(Path.Combine(root, "CHANGELOG.md"), """
+        # Changelog
+
+        ## ugit 0.4.5.1:
+        > Like It? <a href="https://github.com/StartAutomating/ugit" target="_blank" rel="noopener noreferrer">Star It</a>
+        - fix duplicate commit issue (#334)
+        """);
+
+        var client = new FakeRepoClient();
+        client.Releases.Add(new RepoRelease
+        {
+            Tag = "v0.4.5.1",
+            Name = "ugit 0.4.5.1",
+            Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.5.1",
+            PublishedAt = new DateTimeOffset(2024, 12, 7, 0, 0, 0, TimeSpan.Zero)
+        });
+
+        var planner = new DocumentationPlanner(new DocumentationFinder());
+        var res = planner.Execute(new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            ProjectUri = "https://github.com/StartAutomating/ugit"
+        }, client);
+
+        var releases = Assert.Single(res.Items, i => string.Equals(i.Kind, "RELEASES", StringComparison.OrdinalIgnoreCase));
+        var latest = Assert.Single(releases.Releases!);
+        Assert.Equal("v0.4.5.1", latest.Tag);
+        Assert.Equal("https://github.com/StartAutomating/ugit/releases/tag/v0.4.5.1", latest.Url);
+        Assert.Equal("2024-12-07", latest.PublishedAt?.ToString("yyyy-MM-dd"));
+        Assert.Contains("[#334](https://github.com/StartAutomating/ugit/issues/334)", latest.Body, StringComparison.Ordinal);
+        Assert.DoesNotContain("target=\"_blank\"", latest.Body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rel=\"noopener noreferrer\"", latest.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Changelog_Infers_VPrefixed_GitHub_Tag_For_Plain_Release_Heading()
+    {
+        var root = CreateTempModule(out var internals);
+        File.WriteAllText(Path.Combine(root, "CHANGELOG.md"), """
+        # Changelog
+
+        ## ugit 0.4.5.1:
+        - fix duplicate commit issue (#334)
+        """);
+
+        var planner = new DocumentationPlanner(new DocumentationFinder());
+        var res = planner.Execute(new DocumentationPlanner.Request
+        {
+            RootBase = root,
+            InternalsBase = internals,
+            ProjectUri = "https://github.com/StartAutomating/ugit"
+        });
+
+        var releases = Assert.Single(res.Items, i => string.Equals(i.Kind, "RELEASES", StringComparison.OrdinalIgnoreCase));
+        var latest = Assert.Single(releases.Releases!);
+        Assert.Equal("v0.4.5.1", latest.Tag);
+        Assert.Equal("https://github.com/StartAutomating/ugit/releases/tag/v0.4.5.1", latest.Url);
+        Assert.DoesNotContain(':', latest.Name);
+    }
+
+    private sealed class FakeRepoClient : IRepoClient
+    {
+        public Dictionary<string, List<(string Name, string Path)>> Files { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, string> Content { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public List<RepoRelease> Releases { get; } = new();
+
+        public string GetDefaultBranch() => "main";
+
+        public string? GetFileContent(string path, string branch)
+            => Content.TryGetValue(path, out var value) ? value : null;
+
+        public List<(string Name, string Path)> ListFiles(string path, string branch)
+            => Files.TryGetValue(path, out var value) ? value : new List<(string Name, string Path)>();
+
+        public List<RepoRelease> ListReleases() => Releases;
     }
 }

--- a/PSMaintenance.Tests/HtmlExporterMarkdownTests.cs
+++ b/PSMaintenance.Tests/HtmlExporterMarkdownTests.cs
@@ -56,4 +56,261 @@ public class HtmlExporterMarkdownTests
             }
         }
     }
+
+    [Fact]
+    public void Export_Renders_Structured_Releases_With_Release_Cards()
+    {
+        var exporter = new HtmlExporter();
+        var module = new ModuleInfoModel
+        {
+            Name = "ugit",
+            Version = "1.0.0",
+            SkipCommands = true,
+            SkipDependencies = true
+        };
+
+        var items = new[]
+        {
+            new DocumentItem
+            {
+                Title = "Releases",
+                Kind = "RELEASES",
+                Releases = new()
+                {
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.4.5.1",
+                        Tag = "v0.4.5.1",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.5.1",
+                        PublishedAt = new DateTimeOffset(2024, 12, 7, 0, 0, 0, TimeSpan.Zero),
+                        Body = "- Fixed duplicate commit issue",
+                        IsPrerelease = false
+                    },
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.4.6-preview1",
+                        Tag = "v0.4.6-preview1",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.6-preview1",
+                        PublishedAt = new DateTimeOffset(2025, 1, 3, 0, 0, 0, TimeSpan.Zero),
+                        Body = "- Preview notes",
+                        IsPrerelease = true
+                    }
+                }
+            }
+        };
+
+        items[0].Releases![0].Assets.Add(new RepoReleaseAsset
+        {
+            Name = "ugit.zip",
+            DownloadUrl = "https://github.com/StartAutomating/ugit/releases/download/v0.4.5.1/ugit.zip",
+            Size = 1024,
+            ContentType = "application/zip"
+        });
+
+        var outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+
+        try
+        {
+            exporter.Export(module, items, outputPath, open: false);
+
+            var html = File.ReadAllText(outputPath);
+            Assert.Contains("Release Overview", html, StringComparison.Ordinal);
+            Assert.Contains("Latest Stable", html, StringComparison.Ordinal);
+            Assert.Contains("Latest Preview", html, StringComparison.Ordinal);
+            Assert.Contains("ugit 0.4.5.1", html, StringComparison.Ordinal);
+            Assert.Contains("Fixed duplicate commit issue", html, StringComparison.Ordinal);
+            Assert.Contains("Release Downloads", html, StringComparison.Ordinal);
+            Assert.Contains("ugit.zip", html, StringComparison.Ordinal);
+            Assert.Contains("https://github.com/StartAutomating/ugit/releases/tag/v0.4.5.1", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Export_Sorts_Releases_By_Version_When_Published_Dates_Are_Missing()
+    {
+        var exporter = new HtmlExporter();
+        var module = new ModuleInfoModel
+        {
+            Name = "ugit",
+            Version = "1.0.0",
+            SkipCommands = true,
+            SkipDependencies = true
+        };
+
+        var items = new[]
+        {
+            new DocumentItem
+            {
+                Title = "Releases",
+                Kind = "RELEASES",
+                Releases = new()
+                {
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.4.9",
+                        Tag = "v0.4.9",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.9",
+                        Body = "- Stable release",
+                        IsPrerelease = false
+                    },
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.4.10",
+                        Tag = "v0.4.10",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.10",
+                        Body = "- Newer stable release",
+                        IsPrerelease = false
+                    },
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.4.10-preview1",
+                        Tag = "v0.4.10-preview1",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.4.10-preview1",
+                        Body = "- Preview release",
+                        IsPrerelease = true
+                    }
+                }
+            }
+        };
+
+        var outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+
+        try
+        {
+            exporter.Export(module, items, outputPath, open: false);
+
+            var html = File.ReadAllText(outputPath);
+            Assert.Contains("Latest release", html, StringComparison.Ordinal);
+            Assert.Contains("Latest stable", html, StringComparison.Ordinal);
+            Assert.Contains("Latest preview", html, StringComparison.Ordinal);
+
+            var latestReleaseIndex = html.IndexOf("ugit 0.4.10", StringComparison.Ordinal);
+            var olderReleaseIndex = html.IndexOf("ugit 0.4.9", StringComparison.Ordinal);
+            Assert.True(latestReleaseIndex >= 0, "Expected latest stable release label to be rendered.");
+            Assert.True(olderReleaseIndex >= 0, "Expected older stable release label to be rendered.");
+            Assert.True(latestReleaseIndex < olderReleaseIndex, "Expected version-aware ordering to place 0.4.10 ahead of 0.4.9 when publish dates are missing.");
+            Assert.Contains("Latest Stable", html, StringComparison.Ordinal);
+            Assert.Contains("Latest Preview", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Export_Renders_Release_Body_Issue_Links_Without_Corrupt_Target_Attributes()
+    {
+        var exporter = new HtmlExporter();
+        var module = new ModuleInfoModel
+        {
+            Name = "ugit",
+            Version = "1.0.0",
+            SkipCommands = true,
+            SkipDependencies = true
+        };
+
+        var items = new[]
+        {
+            new DocumentItem
+            {
+                Title = "Releases",
+                Kind = "RELEASES",
+                Releases = new()
+                {
+                    new RepoRelease
+                    {
+                        Name = "ugit 0.1.5",
+                        Tag = "v0.1.5",
+                        Url = "https://github.com/StartAutomating/ugit/releases/tag/v0.1.5",
+                        Body = """
+                        * Adding git.log .Checkout() and Revert() ([#27](https://github.com/StartAutomating/ugit/issues/27), [#28](https://github.com/StartAutomating/ugit/issues/28))
+                        * Use-Git: Support for progress bars ([#18](https://github.com/StartAutomating/ugit/issues/18)). Warning when repo not found ([#21](https://github.com/StartAutomating/ugit/issues/21))
+                        """,
+                        IsPrerelease = false
+                    }
+                }
+            }
+        };
+
+        var outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+
+        try
+        {
+            exporter.Export(module, items, outputPath, open: false);
+
+            var html = File.ReadAllText(outputPath);
+            Assert.DoesNotContain("target=\"<em>blank\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("target=\"</em>blank\"", html, StringComparison.Ordinal);
+            Assert.Contains("https://github.com/StartAutomating/ugit/issues/27", html, StringComparison.Ordinal);
+            Assert.Contains("https://github.com/StartAutomating/ugit/issues/28", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Export_Renders_Format_Type_Content_As_Text_Code()
+    {
+        var exporter = new HtmlExporter();
+        var module = new ModuleInfoModel
+        {
+            Name = "ugit",
+            Version = "1.0.0",
+            SkipCommands = true,
+            SkipDependencies = true
+        };
+
+        var items = new[]
+        {
+            new DocumentItem
+            {
+                Title = "ugit.format.ps1xml",
+                Kind = "FORMAT",
+                Source = "Local",
+                Content = """
+                ```xml
+                <Configuration>
+                  <ViewDefinitions />
+                </Configuration>
+                ```
+                """
+            }
+        };
+
+        var outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+
+        try
+        {
+            exporter.Export(module, items, outputPath, open: false);
+
+            var html = File.ReadAllText(outputPath);
+            Assert.DoesNotContain("language-xml", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("token tag", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Configuration", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("ViewDefinitions", html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
 }

--- a/PSMaintenance.Tests/RepositoryContentNormalizerTests.cs
+++ b/PSMaintenance.Tests/RepositoryContentNormalizerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Xunit;
+
+namespace PSMaintenance.Tests;
+
+public class RepositoryContentNormalizerTests
+{
+    [Fact]
+    public void RewriteRelativeUris_Rewrites_Markdown_And_RawHtml_Assets()
+    {
+        var content = """
+        <img src='assets/ugit.svg' alt='ugit' />
+        <a href="docs/Out-Git.md" target="_blank" rel="noopener noreferrer">Out-Git</a>
+        [Use-Git](docs/Use-Git.md)
+        """;
+
+        var rewritten = RepositoryContentNormalizer.RewriteRelativeUris(
+            content,
+            "https://raw.githubusercontent.com/StartAutomating/ugit/main/",
+            "https://github.com/StartAutomating/ugit/blob/main/");
+
+        Assert.Contains("https://raw.githubusercontent.com/StartAutomating/ugit/main/assets/ugit.svg", rewritten);
+        Assert.Contains("https://github.com/StartAutomating/ugit/blob/main/docs/Out-Git.md", rewritten);
+        Assert.Contains("https://github.com/StartAutomating/ugit/blob/main/docs/Use-Git.md", rewritten);
+        Assert.DoesNotContain("target=\"_blank\"", rewritten, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rel=\"noopener noreferrer\"", rewritten, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RewriteRelativeUris_Preserves_Fenced_Code_And_RootRelative_Links()
+    {
+        var content = """
+        <a href='/2022/03/20/'>permalink</a>
+        ~~~html
+        <img src='assets/keep.svg' alt='keep' />
+        [Example](docs/Keep.md)
+        ~~~
+        """;
+
+        var rewritten = RepositoryContentNormalizer.RewriteRelativeUris(
+            content,
+            "https://raw.githubusercontent.com/StartAutomating/ugit/main/");
+
+        Assert.Contains("<a href='/2022/03/20/'>permalink</a>", rewritten);
+        Assert.Contains("<img src='assets/keep.svg' alt='keep' />", rewritten);
+        Assert.Contains("[Example](docs/Keep.md)", rewritten);
+    }
+
+    [Fact]
+    public void IsLikelyTemplateSource_Detects_Jekyll_Liquid_Documents()
+    {
+        var content = """
+        ---
+        permalink: /2022/03/20/
+        ---
+
+        {% for post in site.posts %}
+        * [{{ post.title }}]({{ post.url }})
+        {% endfor %}
+        """;
+
+        Assert.True(RepositoryContentNormalizer.IsLikelyTemplateSource("2022-03-20.md", content));
+        Assert.False(RepositoryContentNormalizer.IsLikelyTemplateSource("Use-Git.md", "## Use-Git\n\nRegular markdown."));
+    }
+}

--- a/PSMaintenance/Models/DocumentItem.cs
+++ b/PSMaintenance/Models/DocumentItem.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace PSMaintenance;
 
 /// <summary>
@@ -7,8 +9,8 @@ internal sealed class DocumentItem
 {
     /// <summary>Display title used in console/HTML renderers.</summary>
     public string Title { get; set; } = string.Empty;
-    /// <summary>Logical kind: FILE, INTRO, UPGRADE, LINKS, ABOUT, FORMAT, TYPE, SCRIPT, DOC, COMMUNITY, RELEASES.</summary>
-    public string Kind { get; set; } = "FILE"; // FILE, INTRO, UPGRADE, LINKS, ABOUT, FORMAT, TYPE, SCRIPT, DOC, COMMUNITY, RELEASES
+    /// <summary>Logical kind: FILE, INTRO, UPGRADE, LINKS, ABOUT, FORMAT, TYPE, SCRIPT, DOC, DOCSOURCE, COMMUNITY, RELEASES.</summary>
+    public string Kind { get; set; } = "FILE"; // FILE, INTRO, UPGRADE, LINKS, ABOUT, FORMAT, TYPE, SCRIPT, DOC, DOCSOURCE, COMMUNITY, RELEASES
     /// <summary>Markdown content.</summary>
     public string Content { get; set; } = string.Empty; // markdown content
     /// <summary>Optional local file path when the item represents a file on disk.</summary>
@@ -19,4 +21,6 @@ internal sealed class DocumentItem
     public string? Source { get; set; }
     /// <summary>Optional base URI for resolving relative links/images when rendering.</summary>
     public string? BaseUri { get; set; }
+    /// <summary>Optional typed releases payload used by richer release renderers.</summary>
+    public List<RepoRelease>? Releases { get; set; }
 }

--- a/PSMaintenance/Models/RepoRelease.cs
+++ b/PSMaintenance/Models/RepoRelease.cs
@@ -7,7 +7,10 @@ internal sealed class RepoRelease
 {
     public string Tag { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
+    public string? Url { get; set; }
     public string Body { get; set; } = string.Empty;
+    public bool IsPrerelease { get; set; }
+    public bool IsDraft { get; set; }
     public DateTimeOffset? PublishedAt { get; set; }
         = null;
     public List<RepoReleaseAsset> Assets { get; } = new List<RepoReleaseAsset>();
@@ -22,4 +25,3 @@ internal sealed class RepoReleaseAsset
     public string? ContentType { get; set; }
         = null;
 }
-

--- a/PSMaintenance/PSMaintenance.csproj
+++ b/PSMaintenance/PSMaintenance.csproj
@@ -12,15 +12,18 @@
         <Authors>Przemyslaw Klys</Authors>
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <LangVersion>Latest</LangVersion>
+        <HtmlForgeXVersion Condition="'$(HtmlForgeXVersion)'==''">0.36.0</HtmlForgeXVersion>
+        <HtmlForgeXMarkdownVersion Condition="'$(HtmlForgeXMarkdownVersion)'==''">0.20.4</HtmlForgeXMarkdownVersion>
+        <OfficeImoMarkdownVersion Condition="'$(OfficeImoMarkdownVersion)'==''">0.6.6</OfficeImoMarkdownVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
         <PackageReference Include="Spectre.Console" Version="0.48.0" />
         <PackageReference Include="Spectre.Console.Json" Version="0.48.0" />
-        <PackageReference Include="HtmlForgeX" Version="0.36.0" />
-        <PackageReference Include="HtmlForgeX.Markdown" Version="0.20.4" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.6" />
+        <PackageReference Include="HtmlForgeX" Version="$(HtmlForgeXVersion)" />
+        <PackageReference Include="HtmlForgeX.Markdown" Version="$(HtmlForgeXMarkdownVersion)" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="$(OfficeImoMarkdownVersion)" />
     </ItemGroup>
 
     <!-- Use inbox System.Text.Json on net8.0; add NuGet only for net472 -->

--- a/PSMaintenance/Services/DocumentationPlanner.cs
+++ b/PSMaintenance/Services/DocumentationPlanner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace PSMaintenance;
@@ -124,15 +125,17 @@ internal sealed class DocumentationPlanner
                 bool anyRemote = false;
                 if (!string.IsNullOrEmpty(readme))
                 {
-                    var baseUri = BuildRawBase(req.ProjectUri, branch);
-                    var di = MakeContentItem(req, "README", RewriteRelativeLinks(readme!, baseUri));
+                    var baseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch);
+                    var blobBaseUri = RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch);
+                    var di = MakeContentItem(req, "README", RepositoryContentNormalizer.RewriteRelativeUris(readme!, baseUri, blobBaseUri));
                     di.Source = "Remote"; di.FileName = "README.md"; di.Title = "README"; di.BaseUri = baseUri;
                     res.Items.Add(di); anyRemote = true;
                 }
                 if (!string.IsNullOrEmpty(changelog))
                 {
-                    var baseUri = BuildRawBase(req.ProjectUri, branch);
-                    var di = MakeContentItem(req, "CHANGELOG", RewriteRelativeLinks(changelog!, baseUri));
+                    var baseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch);
+                    var blobBaseUri = RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch);
+                    var di = MakeContentItem(req, "CHANGELOG", RepositoryContentNormalizer.RewriteRelativeUris(changelog!, baseUri, blobBaseUri));
                     di.Source = "Remote"; di.FileName = "CHANGELOG.md"; di.Title = "CHANGELOG"; di.BaseUri = baseUri;
                     res.Items.Add(di); anyRemote = true;
                 }
@@ -164,7 +167,7 @@ internal sealed class DocumentationPlanner
                                         FileName = Name,
                                         Path = Path,
                                         Source = "Remote",
-                                        BaseUri = BuildRawBase(req.ProjectUri, branch)
+                                        BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch)
                                     });
                                     anyRemote = true;
                                     continue;
@@ -176,11 +179,11 @@ internal sealed class DocumentationPlanner
                                     {
                                         Title = Name ?? string.Empty,
                                         Kind = "COMMUNITY",
-                                        Content = RewriteRelativeLinks(content!, BuildRawBase(req.ProjectUri, branch)),
+                                        Content = RepositoryContentNormalizer.RewriteRelativeUris(content!, RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch), RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch)),
                                         FileName = Name,
                                         Path = Path,
                                         Source = "Remote",
-                                        BaseUri = BuildRawBase(req.ProjectUri, branch)
+                                        BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch)
                                     });
                                     anyRemote = true;
                                     continue;
@@ -188,16 +191,25 @@ internal sealed class DocumentationPlanner
 
                             if (ext == ".md" || ext == ".markdown" || ext == ".txt" || ext == ".help" || ext == ".help.txt")
                             {
-                                // Treat repository path content as documentation pages, not standard tabs
+                                var baseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch);
+                                var blobBaseUri = RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch);
+                                var kind = RepositoryContentNormalizer.IsLikelyTemplateSource(Name, content!)
+                                    ? "DOCSOURCE"
+                                    : "DOC";
+                                var normalizedContent = string.Equals(kind, "DOCSOURCE", StringComparison.OrdinalIgnoreCase)
+                                    ? RepositoryContentNormalizer.WrapAsSourceCodeBlock(content!, "markdown")
+                                    : RepositoryContentNormalizer.RewriteRelativeUris(content!, baseUri, blobBaseUri);
+
+                                // Treat repository path content as documentation pages, not standard tabs.
                                 res.Items.Add(new DocumentItem
                                 {
                                     Title = Name ?? string.Empty,
-                                    Kind = "DOC",
-                                    Content = RewriteRelativeLinks(content!, BuildRawBase(req.ProjectUri, branch)),
+                                    Kind = kind,
+                                    Content = normalizedContent,
                                     FileName = Name,
                                     Path = Path,
                                     Source = "Remote",
-                                    BaseUri = BuildRawBase(req.ProjectUri, branch)
+                                    BaseUri = baseUri
                                 });
                                 anyRemote = true;
                             }
@@ -216,7 +228,33 @@ internal sealed class DocumentationPlanner
             {
                 var fileName = System.IO.Path.GetFileName(it.Path);
                 var title = BuildTitle(req, fileName);
-                res.Items.Add(new DocumentItem { Title = title, Kind = "FILE", Path = it.Path, FileName = fileName, Source = "Local" });
+                var content = string.Empty;
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(it.Path) && File.Exists(it.Path))
+                    {
+                        content = File.ReadAllText(it.Path);
+                        if (!string.IsNullOrWhiteSpace(req.ProjectUri))
+                        {
+                            content = RepositoryContentNormalizer.RewriteRelativeUris(
+                                content,
+                                RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch),
+                                RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, req.RepositoryBranch));
+                        }
+                    }
+                }
+                catch { }
+
+                res.Items.Add(new DocumentItem
+                {
+                    Title = title,
+                    Kind = "FILE",
+                    Path = it.Path,
+                    FileName = fileName,
+                    Source = "Local",
+                    Content = content,
+                    BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch)
+                });
                 continue;
             }
             if (it.Kind == "INTRO")
@@ -279,14 +317,30 @@ internal sealed class DocumentationPlanner
             foreach (var f in formats)
             {
                 var content = System.IO.File.ReadAllText(f.FullName);
-                res.Items.Add(new DocumentItem { Title = BuildTitle(req, f.Name), Kind = "FORMAT", Path = f.FullName, FileName = f.Name, Content = "```xml\n" + content + "\n```", Source = "Local" });
+                res.Items.Add(new DocumentItem
+                {
+                    Title = BuildTitle(req, f.Name),
+                    Kind = "FORMAT",
+                    Path = f.FullName,
+                    FileName = f.Name,
+                    Content = RepositoryContentNormalizer.WrapAsSourceCodeBlock(content, "text"),
+                    Source = "Local"
+                });
             }
 
             var types = _finder.ResolveTypesFiles((req.RootBase, req.InternalsBase, new DeliveryOptions()), req.TypesToProcess);
             foreach (var f in types)
             {
                 var content = System.IO.File.ReadAllText(f.FullName);
-                res.Items.Add(new DocumentItem { Title = BuildTitle(req, f.Name), Kind = "TYPE", Path = f.FullName, FileName = f.Name, Content = "```xml\n" + content + "\n```", Source = "Local" });
+                res.Items.Add(new DocumentItem
+                {
+                    Title = BuildTitle(req, f.Name),
+                    Kind = "TYPE",
+                    Path = f.FullName,
+                    FileName = f.Name,
+                    Content = RepositoryContentNormalizer.WrapAsSourceCodeBlock(content, "text"),
+                    Source = "Local"
+                });
             }
         }
         catch { }
@@ -298,7 +352,14 @@ internal sealed class DocumentationPlanner
             foreach (var f in community)
             {
                 string content; try { content = File.ReadAllText(f.FullName); } catch { continue; }
-                res.Items.Add(new DocumentItem { Title = BuildTitle(req, f.Name), Kind = "COMMUNITY", Path = f.FullName, FileName = f.Name, Content = content, Source = "Local" });
+                if (!string.IsNullOrWhiteSpace(req.ProjectUri))
+                {
+                    content = RepositoryContentNormalizer.RewriteRelativeUris(
+                        content,
+                        RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch),
+                        RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, req.RepositoryBranch));
+                }
+                res.Items.Add(new DocumentItem { Title = BuildTitle(req, f.Name), Kind = "COMMUNITY", Path = f.FullName, FileName = f.Name, Content = content, Source = "Local", BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch) });
             }
         }
         catch { }
@@ -324,12 +385,12 @@ internal sealed class DocumentationPlanner
                     if (forceRemoteStandard || !hasReadme)
                     {
                         var readme = TryFetchFirst(client, branch, new[] { "README.md", "README.MD", "Readme.md" });
-                        if (!string.IsNullOrEmpty(readme)) { var di = MakeContentItem(req, "README", RewriteRelativeLinks(readme!, BuildRawBase(req.ProjectUri, branch))); di.Source = "Remote"; di.FileName = "README.md"; di.Title = "README"; res.Items.Add(di); }
+                        if (!string.IsNullOrEmpty(readme)) { var di = MakeContentItem(req, "README", RepositoryContentNormalizer.RewriteRelativeUris(readme!, RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch), RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch))); di.Source = "Remote"; di.FileName = "README.md"; di.Title = "README"; res.Items.Add(di); }
                     }
                     if (forceRemoteStandard || !hasChlog)
                     {
                         var ch = TryFetchFirst(client, branch, new[] { "CHANGELOG.md", "CHANGELOG.MD", "Changelog.md" });
-                        if (!string.IsNullOrEmpty(ch)) { var di = MakeContentItem(req, "CHANGELOG", RewriteRelativeLinks(ch!, BuildRawBase(req.ProjectUri, branch))); di.Source = "Remote"; di.FileName = "CHANGELOG.md"; di.Title = "CHANGELOG"; res.Items.Add(di); }
+                        if (!string.IsNullOrEmpty(ch)) { var di = MakeContentItem(req, "CHANGELOG", RepositoryContentNormalizer.RewriteRelativeUris(ch!, RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch), RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch))); di.Source = "Remote"; di.FileName = "CHANGELOG.md"; di.Title = "CHANGELOG"; res.Items.Add(di); }
                     }
                     if (forceRemoteStandard || !hasLic)
                     {
@@ -400,15 +461,23 @@ internal sealed class DocumentationPlanner
                                 if (string.IsNullOrEmpty(content)) continue;
                                 if (f.Name.StartsWith("about_", StringComparison.OrdinalIgnoreCase) && f.Name.EndsWith(".help.txt", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    res.Items.Add(new DocumentItem { Title = f.Name, Kind = "ABOUT", Content = AboutToMarkdown(content!), FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = BuildRawBase(req.ProjectUri, branch2) });
+                                    res.Items.Add(new DocumentItem { Title = f.Name, Kind = "ABOUT", Content = AboutToMarkdown(content!), FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch2) });
                                     continue;
                                 }
                                 if (IsCommunityFile(f.Name))
                                 {
-                                    res.Items.Add(new DocumentItem { Title = f.Name, Kind = "COMMUNITY", Content = RewriteRelativeLinks(content!, BuildRawBase(req.ProjectUri, branch2)), FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = BuildRawBase(req.ProjectUri, branch2) });
+                                    res.Items.Add(new DocumentItem { Title = f.Name, Kind = "COMMUNITY", Content = RepositoryContentNormalizer.RewriteRelativeUris(content!, RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch2), RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch2)), FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch2) });
                                     continue;
                                 }
-                                res.Items.Add(new DocumentItem { Title = f.Name, Kind = "DOC", Content = RewriteRelativeLinks(content!, BuildRawBase(req.ProjectUri, branch2)), FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = BuildRawBase(req.ProjectUri, branch2) });
+                                var baseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, branch2);
+                                var blobBaseUri = RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, branch2);
+                                var kind = RepositoryContentNormalizer.IsLikelyTemplateSource(f.Name, content!)
+                                    ? "DOCSOURCE"
+                                    : "DOC";
+                                var normalizedContent = string.Equals(kind, "DOCSOURCE", StringComparison.OrdinalIgnoreCase)
+                                    ? RepositoryContentNormalizer.WrapAsSourceCodeBlock(content!, "markdown")
+                                    : RepositoryContentNormalizer.RewriteRelativeUris(content!, baseUri, blobBaseUri);
+                                res.Items.Add(new DocumentItem { Title = f.Name, Kind = kind, Content = normalizedContent, FileName = f.Name, Path = f.Path, Source = "Remote", BaseUri = baseUri });
                             }
                         }
                     }
@@ -478,7 +547,17 @@ internal sealed class DocumentationPlanner
                     foreach (var f in ordered)
                     {
                         string content; try { content = File.ReadAllText(f); } catch { continue; }
-                        res.Items.Add(new DocumentItem { Title = Path.GetFileName(f), Kind = "DOC", Content = content, FileName = Path.GetFileName(f), Path = f, Source = "Local" });
+                        var fileName = Path.GetFileName(f);
+                        var kind = RepositoryContentNormalizer.IsLikelyTemplateSource(fileName, content)
+                            ? "DOCSOURCE"
+                            : "DOC";
+                        var normalizedContent = string.Equals(kind, "DOCSOURCE", StringComparison.OrdinalIgnoreCase)
+                            ? RepositoryContentNormalizer.WrapAsSourceCodeBlock(content, "markdown")
+                            : RepositoryContentNormalizer.RewriteRelativeUris(
+                                content,
+                                RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch),
+                                RepositoryContentNormalizer.BuildBlobBase(req.ProjectUri, req.RepositoryBranch));
+                        res.Items.Add(new DocumentItem { Title = fileName, Kind = kind, Content = normalizedContent, FileName = fileName, Path = f, Source = "Local", BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, req.RepositoryBranch) });
                     }
                 }
             }
@@ -528,10 +607,26 @@ internal sealed class DocumentationPlanner
             }
             if (!string.IsNullOrEmpty(changelogContent))
             {
-                var releasesMd = BuildReleaseSummary(changelogContent!);
-                if (!string.IsNullOrWhiteSpace(releasesMd))
+                var parsedReleases = ParseChangelogReleases(changelogContent!);
+                if (parsedReleases.Count > 0 && !string.IsNullOrWhiteSpace(req.ProjectUri))
                 {
-                    res.Items.Add(new DocumentItem { Title = BuildTitle(req, "Releases"), Kind = "RELEASES", Content = releasesMd, Source = string.IsNullOrEmpty(req.ProjectUri) ? "Local" : "Derived" });
+                    var repoReleases = GetNormalizedRepoReleases(req, clientOverride);
+                    if (repoReleases.Count > 0)
+                    {
+                        parsedReleases = MergeReleaseMetadata(parsedReleases, repoReleases);
+                    }
+                    parsedReleases = NormalizeRepoReleases(parsedReleases, req.ProjectUri);
+                }
+                if (parsedReleases.Count > 0)
+                {
+                    res.Items.Add(new DocumentItem
+                    {
+                        Title = BuildTitle(req, "Releases"),
+                        Kind = "RELEASES",
+                        Content = BuildReleaseSummaryMarkdown(parsedReleases),
+                        Releases = parsedReleases,
+                        Source = string.IsNullOrEmpty(req.ProjectUri) ? "Local" : "Derived"
+                    });
                 }
             }
             // If changelog not present, try repo releases API
@@ -539,41 +634,42 @@ internal sealed class DocumentationPlanner
             {
                 try
                 {
-                    if (!string.IsNullOrWhiteSpace(req.ProjectUri)) {
-                        var info = RepoUrlParser.Parse(req.ProjectUri!);
-                        var token = ResolveToken(req.RepositoryToken);
-                        if (string.IsNullOrEmpty(token)) token = TokenStore.GetToken(info.Host) ?? string.Empty;
-                        var client = RepoClientFactory.Create(info, token);
-                        var rels = client?.ListReleases() ?? new List<RepoRelease>();
-                    if (rels.Count > 0)
+                    var normalizedReleases = GetNormalizedRepoReleases(req, clientOverride);
+                    if (normalizedReleases.Count > 0)
                     {
                         var sb = new System.Text.StringBuilder();
-                            sb.AppendLine("# Releases (repository API)");
-                            foreach (var r in rels)
+                        sb.AppendLine("# Releases (repository API)");
+                        foreach (var r in normalizedReleases)
+                        {
+                            sb.Append("## ").Append(string.IsNullOrEmpty(r.Name) ? r.Tag : r.Name);
+                            if (r.PublishedAt.HasValue) sb.Append(" (" + r.PublishedAt.Value.ToString("yyyy-MM-dd") + ")");
+                            sb.AppendLine();
+                            if (!string.IsNullOrWhiteSpace(r.Body))
                             {
-                                sb.Append("## ").Append(string.IsNullOrEmpty(r.Name) ? r.Tag : r.Name);
-                                if (r.PublishedAt.HasValue) sb.Append(" (" + r.PublishedAt.Value.ToString("yyyy-MM-dd") + ")");
-                                sb.AppendLine();
-                                if (!string.IsNullOrWhiteSpace(r.Body))
+                                sb.AppendLine(r.Body.Trim()).AppendLine();
+                            }
+                            if (r.Assets.Count > 0)
+                            {
+                                sb.AppendLine("### Assets");
+                                foreach (var a in r.Assets)
                                 {
-                                    var baseUri = BuildRawBase(req.ProjectUri, r.Tag);
-                                    sb.AppendLine(RewriteRelativeLinks(r.Body.Trim(), baseUri)).AppendLine();
-                                }
-                                if (r.Assets.Count > 0)
-                                {
-                                    sb.AppendLine("### Assets");
-                                    foreach (var a in r.Assets)
-                                    {
-                                        sb.Append("- [").Append(a.Name).Append("](").Append(a.DownloadUrl).Append(")");
-                                        if (a.Size.HasValue) sb.Append($" ({a.Size.Value / 1024} KB)");
-                                        if (!string.IsNullOrEmpty(a.ContentType)) sb.Append($" {a.ContentType}");
-                                        sb.AppendLine();
-                                    }
+                                    sb.Append("- [").Append(a.Name).Append("](").Append(a.DownloadUrl).Append(")");
+                                    if (a.Size.HasValue) sb.Append($" ({a.Size.Value / 1024} KB)");
+                                    if (!string.IsNullOrEmpty(a.ContentType)) sb.Append($" {a.ContentType}");
                                     sb.AppendLine();
                                 }
+                                sb.AppendLine();
                             }
-                            res.Items.Add(new DocumentItem { Title = BuildTitle(req, "Releases"), Kind = "RELEASES", Content = sb.ToString(), Source = "Remote", BaseUri = BuildRawBase(req.ProjectUri, rels.FirstOrDefault()?.Tag) });
                         }
+                        res.Items.Add(new DocumentItem
+                        {
+                            Title = BuildTitle(req, "Releases"),
+                            Kind = "RELEASES",
+                            Content = sb.ToString(),
+                            Releases = normalizedReleases,
+                            Source = "Remote",
+                            BaseUri = RepositoryContentNormalizer.BuildRawBase(req.ProjectUri, normalizedReleases.FirstOrDefault()?.Tag)
+                        });
                     }
                 }
                 catch { }
@@ -659,73 +755,382 @@ internal sealed class DocumentationPlanner
         return sb.ToString();
     }
 
-    private static string BuildReleaseSummary(string changelogContent)
+    private static List<RepoRelease> NormalizeRepoReleases(IEnumerable<RepoRelease> releases, string? projectUri)
     {
-        if (string.IsNullOrWhiteSpace(changelogContent)) return string.Empty;
-        var lines = changelogContent.Replace("\r\n", "\n").Split('\n');
-        var releases = new System.Collections.Generic.List<(string Version,string Title)>();
-        var rx = new System.Text.RegularExpressions.Regex("^##\\s*\\[?v?(?<ver>[^\\]]+)\\]?", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        foreach (var line in lines)
+        var normalized = new List<RepoRelease>();
+        foreach (var release in releases.Where(r => r is not null && !r.IsDraft))
         {
-            var m = rx.Match(line.Trim());
-            if (m.Success)
+            var normalizedTag = InferReleaseTag(release.Tag, release.Name);
+            var normalizedName = NormalizeReleaseHeadingTitle(release.Name);
+            var clone = new RepoRelease
             {
-                var ver = m.Groups["ver"].Value.Trim();
-                releases.Add((ver, line.TrimStart('#',' ')));
+                Tag = normalizedTag,
+                Name = normalizedName,
+                Url = string.IsNullOrWhiteSpace(release.Url) ? BuildReleaseUrl(projectUri, normalizedTag) : release.Url,
+                IsDraft = release.IsDraft,
+                IsPrerelease = release.IsPrerelease || IsLikelyPrerelease(normalizedTag, normalizedName),
+                PublishedAt = release.PublishedAt,
+                Body = NormalizeReleaseBody(release.Body, projectUri, normalizedTag)
+            };
+            foreach (var asset in release.Assets)
+            {
+                clone.Assets.Add(new RepoReleaseAsset
+                {
+                    Name = asset.Name,
+                    DownloadUrl = asset.DownloadUrl,
+                    Size = asset.Size,
+                    ContentType = asset.ContentType
+                });
+            }
+
+            normalized.Add(clone);
+        }
+
+        return normalized;
+    }
+
+    private static List<RepoRelease> ParseChangelogReleases(string changelogContent)
+    {
+        var releases = new List<RepoRelease>();
+        if (string.IsNullOrWhiteSpace(changelogContent))
+            return releases;
+
+        var lines = changelogContent.Replace("\r\n", "\n").Split('\n');
+        RepoRelease? current = null;
+        var body = new StringBuilder();
+        var headingRegex = new Regex("^##\\s*(?<title>.+)$", RegexOptions.IgnoreCase);
+        var tagRegex = new Regex("\\[(?<tag>[^\\]]+)\\]|\\b(v?\\d+\\.\\d+[^ ]*)", RegexOptions.IgnoreCase);
+        var dateRegex = new Regex("\\b(?<date>\\d{4}-\\d{2}-\\d{2})\\b", RegexOptions.CultureInvariant);
+
+        foreach (var rawLine in lines)
+        {
+            var trimmedLine = rawLine.TrimEnd();
+            var headingMatch = headingRegex.Match(trimmedLine.Trim());
+            if (headingMatch.Success)
+            {
+                if (current is not null)
+                {
+                    current.Body = body.ToString().Trim();
+                    releases.Add(current);
+                }
+
+                body.Clear();
+                var title = NormalizeReleaseHeadingTitle(headingMatch.Groups["title"].Value.Trim());
+                var tag = string.Empty;
+                var tagMatch = tagRegex.Match(title);
+                if (tagMatch.Success)
+                {
+                    tag = NormalizeReleaseToken(tagMatch.Groups["tag"].Success
+                        ? tagMatch.Groups["tag"].Value.Trim()
+                        : tagMatch.Groups[2].Value.Trim());
+                }
+
+                DateTimeOffset? publishedAt = null;
+                var dateMatch = dateRegex.Match(title);
+                if (dateMatch.Success && DateTimeOffset.TryParse(dateMatch.Groups["date"].Value, out var parsedDate))
+                    publishedAt = parsedDate;
+
+                current = new RepoRelease
+                {
+                    Tag = tag,
+                    Name = title,
+                    Url = null,
+                    IsPrerelease = IsLikelyPrerelease(tag, title),
+                    PublishedAt = publishedAt
+                };
+
+                continue;
+            }
+
+            if (current is not null)
+                body.AppendLine(rawLine);
+        }
+
+        if (current is not null)
+        {
+            current.Body = body.ToString().Trim();
+            releases.Add(current);
+        }
+
+        return releases;
+    }
+
+    private static string BuildReleaseSummaryMarkdown(IEnumerable<RepoRelease> releases)
+    {
+        var releaseList = releases.ToList();
+        if (releaseList.Count == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Releases");
+        sb.AppendLine();
+        sb.AppendLine($"- Total releases: {releaseList.Count}");
+        var latest = releaseList.OrderByDescending(r => r.PublishedAt ?? DateTimeOffset.MinValue).FirstOrDefault();
+        if (latest is not null)
+        {
+            var latestLabel = string.IsNullOrWhiteSpace(latest.Name) ? latest.Tag : latest.Name;
+            if (!string.IsNullOrWhiteSpace(latestLabel))
+                sb.AppendLine($"- Latest: {latestLabel}");
+        }
+        sb.AppendLine();
+
+        foreach (var r in releaseList)
+        {
+            var label = string.IsNullOrWhiteSpace(r.Name) ? r.Tag : r.Name;
+            if (string.IsNullOrWhiteSpace(label))
+                label = "Release";
+
+            sb.Append("## ").Append(label);
+            if (r.PublishedAt.HasValue)
+                sb.Append(" (").Append(r.PublishedAt.Value.ToString("yyyy-MM-dd")).Append(')');
+            sb.AppendLine();
+
+            if (!string.IsNullOrWhiteSpace(r.Body))
+                sb.AppendLine(r.Body.Trim()).AppendLine();
+
+            if (r.Assets.Count > 0)
+            {
+                sb.AppendLine("### Assets");
+                foreach (var asset in r.Assets)
+                {
+                    sb.Append("- [").Append(asset.Name).Append("](").Append(asset.DownloadUrl).Append(')');
+                    if (asset.Size.HasValue)
+                        sb.Append(" (").Append(asset.Size.Value / 1024).Append(" KB)");
+                    sb.AppendLine();
+                }
+                sb.AppendLine();
             }
         }
-        if (releases.Count == 0) return string.Empty;
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("# Releases (from CHANGELOG)");
-        foreach (var r in releases)
-        {
-            sb.Append("- ").Append(r.Version).AppendLine();
-        }
+
         return sb.ToString();
     }
 
-    private static string? BuildRawBase(string? projectUri, string? refName)
+    private static List<RepoRelease> GetNormalizedRepoReleases(Request req, IRepoClient? clientOverride = null)
     {
-        var normalizedProjectUri = projectUri?.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedProjectUri)) return null;
+        if (string.IsNullOrWhiteSpace(req.ProjectUri))
+            return new List<RepoRelease>();
+
+        var client = clientOverride;
+        if (client is null)
+        {
+            var info = RepoUrlParser.Parse(req.ProjectUri!);
+            var token = ResolveToken(req.RepositoryToken);
+            if (string.IsNullOrEmpty(token))
+                token = TokenStore.GetToken(info.Host) ?? string.Empty;
+
+            client = RepoClientFactory.Create(info, token);
+        }
+        var rels = client?.ListReleases() ?? new List<RepoRelease>();
+        return rels.Count > 0 ? NormalizeRepoReleases(rels, req.ProjectUri) : new List<RepoRelease>();
+    }
+
+    private static List<RepoRelease> MergeReleaseMetadata(IEnumerable<RepoRelease> changelogReleases, IEnumerable<RepoRelease> repoReleases)
+    {
+        var merged = new List<RepoRelease>();
+        var remainingRepoReleases = repoReleases.ToList();
+
+        foreach (var changelogRelease in changelogReleases)
+        {
+            var match = FindMatchingRelease(changelogRelease, remainingRepoReleases);
+            if (match is null)
+            {
+                merged.Add(changelogRelease);
+                continue;
+            }
+
+            remainingRepoReleases.Remove(match);
+            var mergedRelease = new RepoRelease
+            {
+                Tag = string.IsNullOrWhiteSpace(changelogRelease.Tag) ? match.Tag : changelogRelease.Tag,
+                Name = string.IsNullOrWhiteSpace(changelogRelease.Name) ? match.Name : changelogRelease.Name,
+                Url = string.IsNullOrWhiteSpace(changelogRelease.Url) ? match.Url : changelogRelease.Url,
+                IsDraft = changelogRelease.IsDraft || match.IsDraft,
+                IsPrerelease = changelogRelease.IsPrerelease || match.IsPrerelease,
+                PublishedAt = changelogRelease.PublishedAt ?? match.PublishedAt,
+                Body = string.IsNullOrWhiteSpace(changelogRelease.Body) ? match.Body : changelogRelease.Body
+            };
+            foreach (var asset in changelogRelease.Assets.Count > 0 ? changelogRelease.Assets : match.Assets)
+            {
+                mergedRelease.Assets.Add(new RepoReleaseAsset
+                {
+                    Name = asset.Name,
+                    DownloadUrl = asset.DownloadUrl,
+                    Size = asset.Size,
+                    ContentType = asset.ContentType
+                });
+            }
+            merged.Add(mergedRelease);
+        }
+
+        merged.AddRange(remainingRepoReleases);
+        return merged;
+    }
+
+    private static RepoRelease? FindMatchingRelease(RepoRelease release, IEnumerable<RepoRelease> candidates)
+    {
+        var releaseKeys = EnumerateReleaseKeys(release).Where(k => !string.IsNullOrWhiteSpace(k)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (releaseKeys.Count == 0)
+            return null;
+
+        return candidates.FirstOrDefault(candidate => EnumerateReleaseKeys(candidate).Any(k => releaseKeys.Contains(k)));
+    }
+
+    private static IEnumerable<string> EnumerateReleaseKeys(RepoRelease release)
+    {
+        var tag = NormalizeReleaseToken(release.Tag);
+        var name = NormalizeReleaseHeadingTitle(release.Name);
+        var version = ExtractReleaseVersionToken(tag) ?? ExtractReleaseVersionToken(name);
+
+        if (!string.IsNullOrWhiteSpace(tag))
+            yield return tag;
+        if (!string.IsNullOrWhiteSpace(name))
+            yield return name;
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            yield return version!;
+            yield return "v" + version;
+        }
+    }
+
+    private static string NormalizeReleaseBody(string? body, string? projectUri, string? reference)
+    {
+        var normalized = ConvertSimpleHtmlLinksToMarkdown(body ?? string.Empty);
+        normalized = RepositoryContentNormalizer.RewriteRelativeUris(
+            normalized,
+            RepositoryContentNormalizer.BuildRawBase(projectUri, reference),
+            RepositoryContentNormalizer.BuildBlobBase(projectUri, reference));
+
+        return LinkifyIssueReferences(normalized, projectUri);
+    }
+
+    private static string ConvertSimpleHtmlLinksToMarkdown(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return content ?? string.Empty;
+
+        return Regex.Replace(
+            content,
+            @"<a\b[^>]*\bhref\s*=\s*(['""])(?<url>.*?)\1[^>]*>(?<text>.*?)</a>",
+            match =>
+            {
+                var url = match.Groups["url"].Value.Trim();
+                var text = Regex.Replace(match.Groups["text"].Value, "<.*?>", string.Empty, RegexOptions.Singleline).Trim();
+                if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(text))
+                    return match.Value;
+
+                return $"[{System.Net.WebUtility.HtmlDecode(text)}]({url})";
+            },
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    }
+
+    private static string LinkifyIssueReferences(string content, string? projectUri)
+    {
+        if (string.IsNullOrWhiteSpace(content) || string.IsNullOrWhiteSpace(projectUri))
+            return content ?? string.Empty;
+
         try
         {
-            var info = RepoUrlParser.Parse(normalizedProjectUri!);
-            if (info.Host == RepoHost.GitHub && !string.IsNullOrEmpty(info.Owner) && !string.IsNullOrEmpty(info.Repo))
+            var info = RepoUrlParser.Parse(projectUri!);
+            if (info.Host != RepoHost.GitHub || string.IsNullOrWhiteSpace(info.Owner) || string.IsNullOrWhiteSpace(info.Repo))
+                return content;
+
+            return Regex.Replace(
+                content,
+                @"(^|[\s(])#(?<id>\d+)\b",
+                match => $"{match.Groups[1].Value}[#{match.Groups["id"].Value}](https://github.com/{info.Owner}/{info.Repo}/issues/{match.Groups["id"].Value})",
+                RegexOptions.CultureInvariant | RegexOptions.Multiline);
+        }
+        catch
+        {
+            return content;
+        }
+    }
+
+    private static string? BuildReleaseUrl(string? projectUri, string? tag)
+    {
+        if (string.IsNullOrWhiteSpace(projectUri) || string.IsNullOrWhiteSpace(tag))
+            return null;
+
+        var normalizedProjectUri = projectUri!.Trim();
+        var normalizedTag = tag!.Trim();
+
+        try
+        {
+            var info = RepoUrlParser.Parse(normalizedProjectUri);
+            if (info.Host == RepoHost.GitHub && !string.IsNullOrWhiteSpace(info.Owner) && !string.IsNullOrWhiteSpace(info.Repo))
             {
-                var branch = "main";
-                if (!string.IsNullOrWhiteSpace(refName))
-                {
-                    branch = refName!.Trim();
-                }
-                return $"https://raw.githubusercontent.com/{info.Owner}/{info.Repo}/{branch}/";
+                return $"https://github.com/{info.Owner}/{info.Repo}/releases/tag/{Uri.EscapeDataString(normalizedTag)}";
             }
         }
-        catch { }
+        catch
+        {
+            // Ignore invalid repository URLs and fall back to null.
+        }
+
         return null;
     }
 
-    private static string RewriteRelativeLinks(string markdown, string? baseUri)
+    private static bool IsLikelyPrerelease(string? tag, string? name)
     {
-        if (string.IsNullOrWhiteSpace(markdown) || string.IsNullOrWhiteSpace(baseUri)) return markdown ?? string.Empty;
-        string repl(Match m)
-        {
-            var url = m.Groups[2].Value;
-            if (string.IsNullOrWhiteSpace(url)) return m.Value;
-            if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) return m.Value;
-            if (url.StartsWith("//") || url.StartsWith("#") || url.StartsWith("mailto:") || url.StartsWith("data:")) return m.Value;
-            try
-            {
-                var abs = new Uri(new Uri(baseUri!, UriKind.Absolute), url).ToString();
-                return m.Groups[1].Value + abs + m.Groups[3].Value;
-            }
-            catch { return m.Value; }
-        }
+        var text = string.Join(" ", new[] { tag ?? string.Empty, name ?? string.Empty }).Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
 
-        // Matches [text](url) and ![alt](url)
-        var pattern = @"(!?\[[^\]]*\]\()([^\)]+)(\))";
-        return Regex.Replace(markdown, pattern, new MatchEvaluator(repl));
+        return text.Contains("preview", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("prerelease", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("pre-release", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("alpha", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("beta", StringComparison.OrdinalIgnoreCase)
+               || Regex.IsMatch(text, @"(?<![a-z])rc[\.-]?\d*", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     }
+
+    private static string NormalizeReleaseHeadingTitle(string? title)
+    {
+        var normalized = title ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalized))
+            return string.Empty;
+
+        normalized = normalized.Trim();
+        return normalized.TrimEnd(':', ';', ',', ')', ']');
+    }
+
+    private static string NormalizeReleaseToken(string? token)
+    {
+        var normalized = token ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalized))
+            return string.Empty;
+
+        normalized = normalized.Trim();
+        return normalized.TrimEnd(':', ';', ',', ')', ']');
+    }
+
+    private static string InferReleaseTag(string? tag, string? name)
+    {
+        var normalizedTag = NormalizeReleaseToken(tag);
+        if (!string.IsNullOrWhiteSpace(normalizedTag))
+            return normalizedTag;
+
+        var version = ExtractReleaseVersionToken(name);
+        if (string.IsNullOrWhiteSpace(version))
+            return string.Empty;
+
+        return "v" + version;
+    }
+
+    private static string? ExtractReleaseVersionToken(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var match = Regex.Match(text, @"\bv?(?<version>\d+(?:\.\d+)+(?:[-a-z0-9\.]+)?)\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        return match.Success ? match.Groups["version"].Value : null;
+    }
+
+    private static string? BuildRawBase(string? projectUri, string? refName)
+        => RepositoryContentNormalizer.BuildRawBase(projectUri, refName);
+
+    private static string RewriteRelativeLinks(string markdown, string? baseUri)
+        => RepositoryContentNormalizer.RewriteRelativeUris(markdown, baseUri);
 
     private static object? GetDeliveryValue(object? delivery, string name)
     {

--- a/PSMaintenance/Services/GitHubRepository.cs
+++ b/PSMaintenance/Services/GitHubRepository.cs
@@ -130,7 +130,10 @@ internal sealed class GitHubRepository : IRepoClient
                 var r = new RepoRelease();
                 r.Tag = rel.TryGetProperty("tag_name", out var tag) ? tag.GetString() ?? string.Empty : string.Empty;
                 r.Name = rel.TryGetProperty("name", out var name) ? name.GetString() ?? r.Tag : r.Tag;
+                r.Url = rel.TryGetProperty("html_url", out var html) ? html.GetString() : null;
                 r.Body = rel.TryGetProperty("body", out var body) ? (body.GetString() ?? string.Empty) : string.Empty;
+                r.IsDraft = rel.TryGetProperty("draft", out var draft) && draft.ValueKind == JsonValueKind.True;
+                r.IsPrerelease = rel.TryGetProperty("prerelease", out var prerelease) && prerelease.ValueKind == JsonValueKind.True;
                 if (rel.TryGetProperty("published_at", out var pub) && pub.ValueKind == JsonValueKind.String && DateTimeOffset.TryParse(pub.GetString(), out var dto)) r.PublishedAt = dto;
                 if (rel.TryGetProperty("assets", out var assetsEl) && assetsEl.ValueKind == JsonValueKind.Array)
                 {

--- a/PSMaintenance/Services/HtmlExporter.cs
+++ b/PSMaintenance/Services/HtmlExporter.cs
@@ -58,6 +58,7 @@ internal sealed class HtmlExporter
                                 // Standard docs (everything except SCRIPT/DOC/ABOUT/FORMAT/TYPE/COMMUNITY/RELEASES kinds)
                                 var standard = list.Where(x => !string.Equals(x.Kind, "SCRIPT", System.StringComparison.OrdinalIgnoreCase)
                                                            && !string.Equals(x.Kind, "DOC", System.StringComparison.OrdinalIgnoreCase)
+                                                           && !string.Equals(x.Kind, "DOCSOURCE", System.StringComparison.OrdinalIgnoreCase)
                                                            && !string.Equals(x.Kind, "ABOUT", System.StringComparison.OrdinalIgnoreCase)
                                                            && !string.Equals(x.Kind, "FORMAT", System.StringComparison.OrdinalIgnoreCase)
                                                            && !string.Equals(x.Kind, "TYPE", System.StringComparison.OrdinalIgnoreCase)
@@ -326,6 +327,68 @@ internal sealed class HtmlExporter
             });
         }
 
+                                // Documentation source templates (Liquid/Jekyll or similar)
+        var docSourcesAll = list.Where(x => string.Equals(x.Kind, "DOCSOURCE", System.StringComparison.OrdinalIgnoreCase)).ToList();
+        if (docSourcesAll.Count > 0)
+        {
+            var docSourcesLocal = docSourcesAll.Where(x => string.Equals(x.Source, "Local", StringComparison.OrdinalIgnoreCase)).ToList();
+            var docSourcesRepo  = docSourcesAll.Where(x => string.Equals(x.Source, "Remote", StringComparison.OrdinalIgnoreCase)).ToList();
+            log?.Invoke($"Adding Source Docs tab with {docSourcesAll.Count} items (Local={docSourcesLocal.Count}, Repo={docSourcesRepo.Count})...");
+            tabs.AddTab("🧱 Source Docs", panel =>
+            {
+                void RenderSourceTabs(TablerTabs innerTabs, IEnumerable<DocumentItem> itemsToRender)
+                {
+                    foreach (var d in itemsToRender)
+                    {
+                        var name = string.IsNullOrWhiteSpace(d.FileName) ? MakeShortTabTitle(d) : d.FileName;
+                        innerTabs.AddTab(name ?? string.Empty, pp =>
+                        {
+                            var md = d.Content;
+                            if (string.IsNullOrWhiteSpace(md) && !string.IsNullOrWhiteSpace(d.Path) && File.Exists(d.Path))
+                            {
+                                md = RepositoryContentNormalizer.WrapAsSourceCodeBlock(File.ReadAllText(d.Path), "markdown");
+                            }
+
+                            pp.Markdown(md ?? string.Empty, new MarkdownOptions
+                            {
+                                HeadingsBaseLevel = 2,
+                                AutolinkBareUrls = true,
+                                Sanitize = true,
+                                AllowRawHtmlInline = true,
+                                AllowRawHtmlBlocks = true
+                            });
+                        });
+                    }
+                }
+
+                if (docSourcesLocal.Count > 0 && docSourcesRepo.Count > 0)
+                {
+                    panel.Tabs(group =>
+                    {
+                        group.AddTab("📄 Local", p =>
+                        {
+                            var inner = new TablerTabs();
+                            p.Add(inner);
+                            RenderSourceTabs(inner, docSourcesLocal);
+                        });
+                        group.AddTab("🌐 Repository", p =>
+                        {
+                            var inner = new TablerTabs();
+                            p.Add(inner);
+                            RenderSourceTabs(inner, docSourcesRepo);
+                        });
+                    });
+                }
+                else
+                {
+                    var render = docSourcesLocal.Count > 0 ? docSourcesLocal : docSourcesRepo;
+                    var inner = new TablerTabs();
+                    panel.Add(inner);
+                    RenderSourceTabs(inner, render);
+                }
+            });
+        }
+
                                 // About topics (about_*.help.txt)
                                 var abouts = list.Where(x => string.Equals(x.Kind, "ABOUT", System.StringComparison.OrdinalIgnoreCase)).ToList();
                                 if (abouts.Count > 0)
@@ -367,8 +430,13 @@ internal sealed class HtmlExporter
                                                     var md = f.Content;
                                                     if (string.IsNullOrWhiteSpace(md) && !string.IsNullOrWhiteSpace(f.Path) && File.Exists(f.Path))
                                                     {
-                                                        md = $"```xml\n{File.ReadAllText(f.Path)}\n```";
+                                                        md = RepositoryContentNormalizer.WrapAsSourceCodeBlock(File.ReadAllText(f.Path), "text");
                                                     }
+                                                    else
+                                                    {
+                                                        md = NormalizeSourceLikeMarkdown(md);
+                                                    }
+
                                                     p.Markdown(md ?? string.Empty, new MarkdownOptions { HeadingsBaseLevel = 2, AutolinkBareUrls = true, Sanitize = true, AllowRawHtmlInline = true, AllowRawHtmlBlocks = true });
                                                 });
                                             }
@@ -409,7 +477,14 @@ internal sealed class HtmlExporter
                                     var rel = releases.Last();
                                     tabs.AddTab("📦 Releases", panel =>
                                     {
-                                        panel.Markdown(rel.Content ?? string.Empty, new MarkdownOptions { HeadingsBaseLevel = 2, AutolinkBareUrls = true, Sanitize = true, AllowRawHtmlInline = true, AllowRawHtmlBlocks = true });
+                                        if (rel.Releases is { Count: > 0 })
+                                        {
+                                            RenderStructuredReleases(panel, rel.Releases);
+                                        }
+                                        else
+                                        {
+                                            panel.Markdown(rel.Content ?? string.Empty, new MarkdownOptions { HeadingsBaseLevel = 2, AutolinkBareUrls = true, Sanitize = true, AllowRawHtmlInline = true, AllowRawHtmlBlocks = true });
+                                        }
                                     });
                                 }
 
@@ -1014,6 +1089,380 @@ internal sealed class HtmlExporter
             var md = string.Join("\n", m.RelatedLinks.Select(l => !string.IsNullOrEmpty(l.Uri) ? $"- [{l.Title}]({l.Uri})" : $"- {l.Title}"));
             panel.Markdown(md, new MarkdownOptions { HeadingsBaseLevel = 3, AutolinkBareUrls = true, Sanitize = true, AllowRawHtmlInline = true, AllowRawHtmlBlocks = true });
         }
+    }
+
+    private static void RenderStructuredReleases(TablerTabsPanel panel, IEnumerable<RepoRelease> releases)
+    {
+        var releaseList = OrderReleases(releases);
+
+        if (releaseList.Count == 0)
+        {
+            panel.Markdown("No releases available.", new MarkdownOptions { HeadingsBaseLevel = 2, Sanitize = true });
+            return;
+        }
+
+        var latest = releaseList[0];
+        var latestStable = releaseList.FirstOrDefault(r => !IsPrerelease(r));
+        var latestPreview = releaseList.FirstOrDefault(IsPrerelease);
+        var totalAssets = releaseList.Sum(r => r.Assets.Count);
+
+        panel.Card(card =>
+        {
+            card.Header(h => h.Title("Release Overview"));
+            card.DataGrid(grid =>
+            {
+                grid.AddItem("Total releases", releaseList.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                grid.AddItem("Total assets", totalAssets.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+                var latestLabel = string.IsNullOrWhiteSpace(latest.Name) ? latest.Tag : latest.Name;
+                if (!string.IsNullOrWhiteSpace(latestLabel))
+                {
+                    grid.AddItem("Latest release", latestLabel!);
+                }
+
+                if (latest.PublishedAt.HasValue)
+                {
+                    grid.AddItem("Latest published", latest.PublishedAt.Value.ToString("yyyy-MM-dd"));
+                }
+
+                if (latestStable is not null)
+                {
+                    grid.AddItem("Latest stable", ResolveReleaseLabel(latestStable));
+                }
+
+                if (latestPreview is not null)
+                {
+                    grid.AddItem("Latest preview", ResolveReleaseLabel(latestPreview));
+                }
+
+                if (!string.IsNullOrWhiteSpace(latest.Url))
+                {
+                    grid.AddItem("Latest release page", new HtmlForgeX.Tags.Anchor(latest.Url!, latest.Url!));
+                }
+            });
+        });
+
+        panel.LineBreak();
+        panel.Tabs(inner =>
+        {
+            inner.AddTab("🕒 Timeline", timeline =>
+            {
+                if (releaseList.Count > 1 || totalAssets > 0)
+                {
+                    var rows = releaseList.Select(release => new
+                    {
+                        Release = ResolveReleaseLabel(release),
+                        Tag = release.Tag ?? string.Empty,
+                        Status = ResolveReleaseStatus(release, latestStable, latestPreview),
+                        Published = release.PublishedAt?.ToString("yyyy-MM-dd") ?? string.Empty,
+                        Assets = release.Assets.Count,
+                        Url = release.Url ?? string.Empty
+                    }).ToList();
+
+                    timeline.Card(card =>
+                    {
+                        card.Header(h => h.Title("Release Index"));
+                        card.DataTable(rows, t => t
+                            .Settings(s => s.Preset(DataTablesPreset.Minimal))
+                            .Settings(s => s.Export(DataTablesExportFormat.Excel, DataTablesExportFormat.CSV, DataTablesExportFormat.Copy))
+                            .Settings(s => s.ToggleViewButton("Switch to ScrollX", ToggleViewMode.ScrollX, persist: true))
+                        );
+                    });
+                }
+
+                foreach (var release in releaseList)
+                {
+                    timeline.LineBreak();
+                    timeline.Card(card =>
+                    {
+                        card.Header(h => h.Title(ResolveReleaseLabel(release)));
+                        card.Body(body =>
+                        {
+                            body.DataGrid(grid =>
+                            {
+                                if (!string.IsNullOrWhiteSpace(release.Tag))
+                                {
+                                    grid.AddItem("Tag", release.Tag);
+                                }
+
+                                grid.AddItem("Status", ResolveReleaseStatus(release, latestStable, latestPreview));
+
+                                if (release.PublishedAt.HasValue)
+                                {
+                                    grid.AddItem("Published", release.PublishedAt.Value.ToString("yyyy-MM-dd"));
+                                }
+
+                                grid.AddItem("Assets", release.Assets.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+                                if (!string.IsNullOrWhiteSpace(release.Url))
+                                {
+                                    grid.AddItem("Release page", new HtmlForgeX.Tags.Anchor(release.Url!, release.Url!));
+                                }
+                            });
+
+                            if (!string.IsNullOrWhiteSpace(release.Body))
+                            {
+                                body.Markdown("### Notes", new MarkdownOptions
+                                {
+                                    HeadingsBaseLevel = 2,
+                                    AutolinkBareUrls = true,
+                                    Sanitize = true,
+                                    AllowRawHtmlInline = true,
+                                    AllowRawHtmlBlocks = true
+                                });
+                                body.Markdown(release.Body.Trim(), new MarkdownOptions
+                                {
+                                    HeadingsBaseLevel = 3,
+                                    AutolinkBareUrls = true,
+                                    OpenLinksInNewTab = false,
+                                    Sanitize = true,
+                                    AllowRawHtmlInline = true,
+                                    AllowRawHtmlBlocks = true,
+                                    AllowRelativeLinks = true,
+                                    TableMode = MarkdownTableMode.DataTables,
+                                    DataTables = new MarkdownDataTablesOptions
+                                    {
+                                        Responsive = true,
+                                        Export = true,
+                                        ExportFormats = new[] { DataTablesExportFormat.Excel, DataTablesExportFormat.CSV, DataTablesExportFormat.Copy },
+                                        StateSave = true
+                                    }
+                                });
+                            }
+
+                            if (release.Assets.Count > 0)
+                            {
+                                body.Markdown("### Assets", new MarkdownOptions
+                                {
+                                    HeadingsBaseLevel = 2,
+                                    Sanitize = true
+                                });
+
+                                var assetRows = release.Assets.Select(asset => new
+                                {
+                                    Name = asset.Name,
+                                    Download = asset.DownloadUrl,
+                                    Size = asset.Size.HasValue ? FormatBytes(asset.Size.Value) : string.Empty,
+                                    Type = asset.ContentType ?? string.Empty
+                                }).ToList();
+
+                                body.DataTable(assetRows, t => t
+                                    .Settings(s => s.Preset(DataTablesPreset.Minimal))
+                                    .Settings(s => s.Export(DataTablesExportFormat.Excel, DataTablesExportFormat.CSV, DataTablesExportFormat.Copy))
+                                    .Settings(s => s.ToggleViewButton("Switch to ScrollX", ToggleViewMode.ScrollX, persist: true))
+                                );
+                            }
+                        });
+                    });
+                }
+            });
+
+            if (totalAssets > 0)
+            {
+                var downloadRows = releaseList
+                    .SelectMany(release => release.Assets.Select(asset => new
+                    {
+                        Release = ResolveReleaseLabel(release),
+                        Tag = release.Tag ?? string.Empty,
+                        Status = ResolveReleaseStatus(release, latestStable, latestPreview),
+                        Published = release.PublishedAt?.ToString("yyyy-MM-dd") ?? string.Empty,
+                        Name = asset.Name,
+                        Download = asset.DownloadUrl,
+                        Size = asset.Size.HasValue ? FormatBytes(asset.Size.Value) : string.Empty,
+                        Type = asset.ContentType ?? string.Empty
+                    }))
+                    .ToList();
+
+                inner.AddTab("⬇️ Downloads", downloads =>
+                {
+                    downloads.Card(card =>
+                    {
+                        card.Header(h => h.Title("Release Downloads"));
+                        card.DataTable(downloadRows, t => t
+                            .Settings(s => s.Preset(DataTablesPreset.Minimal))
+                            .Settings(s => s.Export(DataTablesExportFormat.Excel, DataTablesExportFormat.CSV, DataTablesExportFormat.Copy))
+                            .Settings(s => s.ToggleViewButton("Switch to ScrollX", ToggleViewMode.ScrollX, persist: true))
+                        );
+                    });
+                });
+            }
+        });
+    }
+
+    private static string ResolveReleaseLabel(RepoRelease release)
+    {
+        if (!string.IsNullOrWhiteSpace(release.Name))
+            return release.Name;
+        if (!string.IsNullOrWhiteSpace(release.Tag))
+            return release.Tag;
+        return "Release";
+    }
+
+    private static List<RepoRelease> OrderReleases(IEnumerable<RepoRelease> releases)
+    {
+        var releaseList = releases
+            .Where(r => r is not null && !r.IsDraft)
+            .ToList();
+
+        releaseList.Sort(CompareReleasesDescending);
+        return releaseList;
+    }
+
+    private static int CompareReleasesDescending(RepoRelease? left, RepoRelease? right)
+    {
+        if (ReferenceEquals(left, right))
+            return 0;
+        if (left is null)
+            return 1;
+        if (right is null)
+            return -1;
+
+        var publishedComparison = Nullable.Compare(right.PublishedAt, left.PublishedAt);
+        if (publishedComparison != 0)
+            return publishedComparison;
+
+        var versionComparison = CompareReleaseVersions(left, right);
+        if (versionComparison != 0)
+            return -versionComparison;
+
+        return string.Compare(ResolveReleaseLabel(right), ResolveReleaseLabel(left), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CompareReleaseVersions(RepoRelease left, RepoRelease right)
+    {
+        var leftVersion = TryParseReleaseVersion(left, out var parsedLeft, out var leftSuffix, out var leftIsPrerelease);
+        var rightVersion = TryParseReleaseVersion(right, out var parsedRight, out var rightSuffix, out var rightIsPrerelease);
+
+        if (leftVersion && rightVersion)
+        {
+            var versionComparison = parsedLeft.CompareTo(parsedRight);
+            if (versionComparison != 0)
+                return versionComparison;
+
+            if (leftIsPrerelease != rightIsPrerelease)
+                return leftIsPrerelease ? -1 : 1;
+
+            return string.Compare(leftSuffix, rightSuffix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (leftVersion)
+            return 1;
+        if (rightVersion)
+            return -1;
+
+        return string.Compare(ResolveReleaseLabel(left), ResolveReleaseLabel(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryParseReleaseVersion(RepoRelease release, out Version version, out string suffix, out bool isPrerelease)
+    {
+        var token = string.Join(" ", new[] { release.Tag ?? string.Empty, release.Name ?? string.Empty });
+        var match = System.Text.RegularExpressions.Regex.Match(
+            token,
+            @"\bv?(?<version>\d+(?:\.\d+){1,3})(?<suffix>[-a-z][a-z0-9\.-]*)?\b",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+
+        if (!match.Success || !Version.TryParse(match.Groups["version"].Value, out version!))
+        {
+            version = new Version(0, 0);
+            suffix = string.Empty;
+            isPrerelease = false;
+            return false;
+        }
+
+        suffix = match.Groups["suffix"].Success ? match.Groups["suffix"].Value : string.Empty;
+        isPrerelease = !string.IsNullOrWhiteSpace(suffix);
+        return true;
+    }
+
+    private static string ResolveReleaseStatus(RepoRelease release, RepoRelease? latestStable, RepoRelease? latestPreview)
+    {
+        if (latestStable is not null && ReferenceEquals(release, latestStable))
+            return "Latest Stable";
+        if (latestPreview is not null && ReferenceEquals(release, latestPreview))
+            return "Latest Preview";
+        return IsPrerelease(release) ? "Preview" : "Stable";
+    }
+
+    private static bool IsPrerelease(RepoRelease release)
+    {
+        if (release.IsPrerelease)
+            return true;
+
+        var combined = string.Join(" ", new[] { release.Tag ?? string.Empty, release.Name ?? string.Empty });
+        return combined.Contains("preview", StringComparison.OrdinalIgnoreCase)
+               || combined.Contains("prerelease", StringComparison.OrdinalIgnoreCase)
+               || combined.Contains("pre-release", StringComparison.OrdinalIgnoreCase)
+               || combined.Contains("alpha", StringComparison.OrdinalIgnoreCase)
+               || combined.Contains("beta", StringComparison.OrdinalIgnoreCase)
+               || System.Text.RegularExpressions.Regex.IsMatch(combined, @"(?<![a-z])rc[\.-]?\d*", System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+    }
+
+    private static string NormalizeSourceLikeMarkdown(string? markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+            return string.Empty;
+
+        var trimmed = markdown!.Trim();
+        if ((trimmed.StartsWith("```", StringComparison.Ordinal) || trimmed.StartsWith("~~~", StringComparison.Ordinal))
+            && TryExtractSingleFencedBlock(trimmed, out var codeContent))
+        {
+            return RepositoryContentNormalizer.WrapAsSourceCodeBlock(codeContent, "text");
+        }
+
+        return RepositoryContentNormalizer.WrapAsSourceCodeBlock(trimmed, "text");
+    }
+
+    private static bool TryExtractSingleFencedBlock(string markdown, out string codeContent)
+    {
+        codeContent = string.Empty;
+        if (string.IsNullOrWhiteSpace(markdown))
+            return false;
+
+        var normalized = markdown.Replace("\r\n", "\n");
+        var lines = normalized.Split('\n');
+        if (lines.Length < 3)
+            return false;
+
+        var firstLine = lines[0].Trim();
+        if (!(firstLine.StartsWith("```", StringComparison.Ordinal) || firstLine.StartsWith("~~~", StringComparison.Ordinal)))
+            return false;
+
+        var markerChar = firstLine[0];
+        var markerLength = 0;
+        while (markerLength < firstLine.Length && firstLine[markerLength] == markerChar)
+        {
+            markerLength++;
+        }
+
+        var closingIndex = lines.Length - 1;
+        while (closingIndex > 0 && string.IsNullOrWhiteSpace(lines[closingIndex]))
+        {
+            closingIndex--;
+        }
+
+        var closingLine = lines[closingIndex].Trim();
+        if (closingLine.Length < markerLength || !closingLine.All(ch => ch == markerChar))
+            return false;
+
+        codeContent = string.Join("\n", lines.Skip(1).Take(closingIndex - 1));
+        return true;
+    }
+
+    private static string FormatBytes(long size)
+    {
+        if (size < 1024)
+            return size.ToString(System.Globalization.CultureInfo.InvariantCulture) + " B";
+
+        double value = size;
+        var suffixes = new[] { "KB", "MB", "GB", "TB" };
+        var suffixIndex = -1;
+        while (value >= 1024 && suffixIndex < suffixes.Length - 1)
+        {
+            value /= 1024;
+            suffixIndex++;
+        }
+
+        return value.ToString(value >= 10 ? "0.#" : "0.##", System.Globalization.CultureInfo.InvariantCulture) + " " + suffixes[Math.Max(suffixIndex, 0)];
     }
 
     private static string NormalizeExampleTitle(string raw, int index)

--- a/PSMaintenance/Services/RepositoryContentNormalizer.cs
+++ b/PSMaintenance/Services/RepositoryContentNormalizer.cs
@@ -1,0 +1,280 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PSMaintenance;
+
+/// <summary>
+/// Normalizes repository-authored markdown so relative links and assets resolve correctly when rendered outside GitHub.
+/// </summary>
+internal static class RepositoryContentNormalizer
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+    private static readonly Regex MarkdownLinkRegex = new(
+        @"(!?\[[^\]]*\]\()([^\)]+)(\))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
+    private static readonly Regex HtmlUrlAttributeRegex = new(
+        @"(?<prefix>\b(?:src|href)\s*=\s*)(?<quote>['""])(?<url>.*?)(\k<quote>)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexTimeout);
+    private static readonly Regex HtmlLinkSafetyAttributeRegex = new(
+        @"\s+(?:target|rel)\s*=\s*(?:(['""]).*?\1|[^\s>]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexTimeout);
+    private static readonly Regex FenceRegex = new(
+        @"^\s*(?<marker>`{3,}|~{3,})",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FrontMatterRegex = new(
+        @"\A---\s*\r?\n.*?\r?\n---\s*(?:\r?\n|$)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline,
+        RegexTimeout);
+    private static readonly Regex DateNamedDocRegex = new(
+        @"^\d{4}(?:-\d{2}){0,2}\.m(?:arkdown|d)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexTimeout);
+
+    internal static string? BuildRawBase(string? projectUri, string? refName)
+    {
+        var normalizedProjectUri = projectUri?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedProjectUri))
+            return null;
+
+        try
+        {
+            var info = RepoUrlParser.Parse(normalizedProjectUri!);
+            if (info.Host == RepoHost.GitHub && !string.IsNullOrEmpty(info.Owner) && !string.IsNullOrEmpty(info.Repo))
+            {
+                var reference = refName;
+                if (string.IsNullOrWhiteSpace(reference))
+                    reference = "main";
+                else
+                    reference = reference!.Trim();
+                return $"https://raw.githubusercontent.com/{info.Owner}/{info.Repo}/{reference.Trim('/')}/";
+            }
+        }
+        catch
+        {
+            // Fall through to null for unsupported/invalid repository URLs.
+        }
+
+        return null;
+    }
+
+    internal static string? BuildBlobBase(string? projectUri, string? refName)
+    {
+        var normalizedProjectUri = projectUri?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedProjectUri))
+            return null;
+
+        try
+        {
+            var info = RepoUrlParser.Parse(normalizedProjectUri!);
+            if (info.Host == RepoHost.GitHub && !string.IsNullOrEmpty(info.Owner) && !string.IsNullOrEmpty(info.Repo))
+            {
+                var reference = refName;
+                if (string.IsNullOrWhiteSpace(reference))
+                    reference = "main";
+                else
+                    reference = reference!.Trim();
+                return $"https://github.com/{info.Owner}/{info.Repo}/blob/{reference.Trim('/')}/";
+            }
+        }
+        catch
+        {
+            // Fall through to null for unsupported/invalid repository URLs.
+        }
+
+        return null;
+    }
+
+    internal static string RewriteRelativeUris(string markdown, string? rawBaseUri)
+        => RewriteRelativeUris(markdown, rawBaseUri, null);
+
+    internal static string RewriteRelativeUris(string markdown, string? rawBaseUri, string? blobBaseUri)
+    {
+        if (string.IsNullOrWhiteSpace(markdown) || string.IsNullOrWhiteSpace(rawBaseUri))
+            return markdown ?? string.Empty;
+
+        var resolvedRawBaseUri = rawBaseUri!;
+        var resolvedBlobBaseUri = blobBaseUri;
+        var usesCrLf = markdown.Contains("\r\n", StringComparison.Ordinal);
+        var normalized = markdown.Replace("\r\n", "\n");
+        var lines = normalized.Split('\n');
+        var builder = new StringBuilder(normalized.Length + 64);
+
+        var inFence = false;
+        char fenceChar = '\0';
+        var fenceLength = 0;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmed = line.TrimStart();
+            var fenceMatch = FenceRegex.Match(trimmed);
+            if (fenceMatch.Success)
+            {
+                var marker = fenceMatch.Groups["marker"].Value;
+                var markerChar = marker[0];
+                var markerLength = marker.Length;
+
+                if (!inFence)
+                {
+                    inFence = true;
+                    fenceChar = markerChar;
+                    fenceLength = markerLength;
+                }
+                else if (markerChar == fenceChar && markerLength >= fenceLength)
+                {
+                    inFence = false;
+                    fenceChar = '\0';
+                    fenceLength = 0;
+                }
+
+                builder.Append(line);
+            }
+            else if (inFence)
+            {
+                builder.Append(line);
+            }
+            else
+            {
+                builder.Append(SanitizeHtmlLinkAttributes(RewriteHtmlAttributes(RewriteMarkdownLinks(line, resolvedRawBaseUri, resolvedBlobBaseUri), resolvedRawBaseUri, resolvedBlobBaseUri)));
+            }
+
+            if (i < lines.Length - 1)
+                builder.Append('\n');
+        }
+
+        var rewritten = builder.ToString();
+        return usesCrLf ? rewritten.Replace("\n", "\r\n") : rewritten;
+    }
+
+    internal static bool IsLikelyTemplateSource(string? fileName, string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return false;
+
+        var normalizedName = Path.GetFileName(fileName ?? string.Empty);
+        var hasLiquidToken =
+            content.Contains("{%", StringComparison.Ordinal) ||
+            content.Contains("{{", StringComparison.Ordinal) ||
+            content.Contains("{#", StringComparison.Ordinal);
+
+        if (!hasLiquidToken)
+            return false;
+
+        var hasFrontMatter = FrontMatterRegex.IsMatch(content);
+        var hasJekyllHints =
+            content.Contains("site.posts", StringComparison.OrdinalIgnoreCase) ||
+            content.Contains("permalink:", StringComparison.OrdinalIgnoreCase) ||
+            content.Contains("layout:", StringComparison.OrdinalIgnoreCase) ||
+            content.Contains("| date:", StringComparison.OrdinalIgnoreCase) ||
+            content.Contains("friendlydate", StringComparison.OrdinalIgnoreCase);
+
+        return hasFrontMatter || hasJekyllHints || DateNamedDocRegex.IsMatch(normalizedName);
+    }
+
+    internal static string WrapAsSourceCodeBlock(string content, string language = "markdown")
+    {
+        var normalizedLanguage = string.IsNullOrWhiteSpace(language) ? "text" : language.Trim();
+        return $"~~~{normalizedLanguage}\n{content}\n~~~";
+    }
+
+    private static string RewriteMarkdownLinks(string text, string rawBaseUri, string? blobBaseUri)
+    {
+        return MarkdownLinkRegex.Replace(text, match =>
+        {
+            var isImage = match.Groups[1].Value.StartsWith("![", StringComparison.Ordinal);
+            var url = match.Groups[2].Value;
+            if (!ShouldRewriteUrl(url))
+                return match.Value;
+
+            try
+            {
+                var baseUri = !isImage && IsLikelyViewableDocument(url) && !string.IsNullOrWhiteSpace(blobBaseUri)
+                    ? blobBaseUri!
+                    : rawBaseUri;
+                var absolute = new Uri(new Uri(baseUri, UriKind.Absolute), url).ToString();
+                return match.Groups[1].Value + absolute + match.Groups[3].Value;
+            }
+            catch
+            {
+                return match.Value;
+            }
+        });
+    }
+
+    private static string RewriteHtmlAttributes(string text, string rawBaseUri, string? blobBaseUri)
+    {
+        return HtmlUrlAttributeRegex.Replace(text, match =>
+        {
+            var attributePrefix = match.Groups["prefix"].Value;
+            var url = match.Groups["url"].Value;
+            if (!ShouldRewriteUrl(url))
+                return match.Value;
+
+            try
+            {
+                var isHref = attributePrefix.Contains("href", StringComparison.OrdinalIgnoreCase);
+                var baseUri = isHref && IsLikelyViewableDocument(url) && !string.IsNullOrWhiteSpace(blobBaseUri)
+                    ? blobBaseUri!
+                    : rawBaseUri;
+                var absolute = new Uri(new Uri(baseUri, UriKind.Absolute), url).ToString();
+                return match.Groups["prefix"].Value + match.Groups["quote"].Value + absolute + match.Groups["quote"].Value;
+            }
+            catch
+            {
+                return match.Value;
+            }
+        });
+    }
+
+    private static string SanitizeHtmlLinkAttributes(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return text;
+
+        return HtmlLinkSafetyAttributeRegex.Replace(text, string.Empty);
+    }
+
+    private static bool ShouldRewriteUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+
+        var trimmed = (url ?? string.Empty).Trim();
+        return !trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("//", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("#", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("/", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+               && !trimmed.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsLikelyViewableDocument(string url)
+    {
+        var withoutQuery = url.Split('?', '#')[0];
+        var extension = Path.GetExtension(withoutQuery);
+        if (string.IsNullOrWhiteSpace(extension))
+            return false;
+
+        return extension.Equals(".md", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".markdown", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".txt", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".help", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".ps1", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".psm1", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".psd1", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".ps1xml", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".json", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".yml", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".xml", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".cs", StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize repository-authored markdown and HTML links for local rendering
- classify Liquid/Jekyll docs as source docs instead of prose docs
- add typed release rendering, safer release-body link behavior, and version-aware release ordering
- add package-version override properties to make local package validation easier before the next HtmlForgeX.Markdown publish

## Upstream
- local validation against HtmlForgeX follow-up: https://github.com/EvotecIT/HtmlForgeX/pull/138
- after that package is published, bump the default HtmlForgeX.Markdown version here in a small follow-up

## Validation
- dotnet test PSMaintenance.Tests/PSMaintenance.Tests.csproj -c Release --framework net8.0
- dotnet build PSMaintenance/PSMaintenance.csproj -c Release -warnaserror --framework net8.0
- dotnet build PSMaintenance/PSMaintenance.csproj -c Release -warnaserror --framework net472